### PR TITLE
Implemented background grid rendering

### DIFF
--- a/src/Modules/CanvasModule/CanvasRenderer.ts
+++ b/src/Modules/CanvasModule/CanvasRenderer.ts
@@ -1,8 +1,41 @@
-import { type Vector2 } from "../Physics/Vector2";
+import { Vector2 } from "../Physics/Vector2";
 import { type CanvasManager } from "./CanvasManager";
+
+/**
+ * Represents the properties of the grid to be drawn on the canvas.
+ *
+ * @interface
+ * @property {string} originColor - The color of the origin.
+ * @property {string} mainColor - The color of the main lines.
+ * @property {string} secondaryColor - The color of the secondary lines.
+ * @property {number} lineWidth - The width of the lines.
+ * @property {number} unitSize - The separation between grid lines.
+ * @property {Vector2} offset - The offset of the grid.
+ */
+export interface GridProperties {
+    originColor: string
+    mainColor: string
+    secondaryColor: string
+    lineWidth: number
+    unitSize: number
+    offset: Vector2
+    showUnits: boolean
+    unitFont: string
+}
 
 export class CanvasRenderer {
     private readonly c: CanvasRenderingContext2D;
+    public gridProperites: GridProperties = {
+        originColor: "green",
+        mainColor: "rgba(172, 76, 31, 0.5)",
+        secondaryColor: "rgba(255, 255, 255, 0.1",
+        lineWidth: 0.5,
+        unitSize: 25,
+        offset: new Vector2(0, 0),
+        showUnits: true,
+        unitFont: "Century Gothic"
+    };
+
     constructor(
         private readonly cM: CanvasManager
     ) {
@@ -29,5 +62,74 @@ export class CanvasRenderer {
         this.c.moveTo(position.x - size, position.y);
         this.c.lineTo(position.x + size, position.y);
         this.c.stroke();
+    }
+
+    DrawLine(color: string, origin: Vector2, dest: Vector2, width: number): void {
+        this.c.strokeStyle = color;
+        this.c.lineWidth = width;
+        this.c.lineCap = "square";
+        this.c.beginPath();
+        this.c.moveTo(origin.x, origin.y);
+        this.c.lineTo(dest.x, dest.y);
+        this.c.stroke();
+    }
+
+    DrawText(text: string, position: Vector2, color: string, font: string): void {
+        this.c.fillStyle = color;
+        this.c.font = font;
+        this.c.fillText(text, position.x, position.y);
+    }
+
+    DrawGrid(params: Partial<GridProperties> | undefined = undefined): void {
+        const { originColor, mainColor, secondaryColor, lineWidth, unitSize, offset, showUnits, unitFont } =
+            params === undefined ? this.gridProperites : { ...this.gridProperites, ...params };
+
+        const tMatrix = this.c.getTransform();
+        const topLeft = new Vector2(-tMatrix.e, -tMatrix.f);
+
+        const bottomRight = topLeft.add(new Vector2(this.c.canvas.width, this.c.canvas.height));
+
+        const sxLineStart = Math.floor((topLeft.x / unitSize) - 1) * unitSize + offset.x % unitSize;
+        const pxLineStart = Math.floor((topLeft.x / (unitSize * 10)) - 1) * unitSize * 10 + offset.x % unitSize;
+        const syLineStart = Math.floor((topLeft.y / unitSize) - 1) * unitSize + offset.y % unitSize;
+        const pyLineStart = Math.floor((topLeft.y / (unitSize * 10)) - 1) * unitSize * 10 + offset.y % unitSize;
+
+        const sxLineEnd = Math.ceil(bottomRight.x / unitSize) * unitSize;
+        const syLineEnd = Math.ceil(bottomRight.y / unitSize) * unitSize;
+
+        this.DrawCircle("blue", topLeft, 2);
+        this.DrawCircle("blue", bottomRight, 2);
+
+        // Drawing y_axis lines
+        // Secondary color
+        for (let i = sxLineStart; i < bottomRight.x; i += unitSize) {
+            this.DrawLine(secondaryColor, new Vector2(i, syLineStart), new Vector2(i, syLineEnd), lineWidth);
+        }
+
+        // Primary Color
+        for (let i = pxLineStart; i < bottomRight.x; i += unitSize * 10) {
+            let color = mainColor;
+            if (i === offset.x % unitSize) { color = originColor; }
+            if (i > sxLineStart) {
+                this.DrawLine(color, new Vector2(i, syLineStart), new Vector2(i, syLineEnd), lineWidth);
+                if (showUnits) { this.DrawText(String(i), new Vector2(i, bottomRight.y).add(new Vector2(5, -5)), color, unitFont); }
+            }
+        }
+
+        // Draw x_axis lines
+        // Secondary color
+        for (let i = syLineStart; i < bottomRight.y; i += unitSize) {
+            this.DrawLine(secondaryColor, new Vector2(sxLineStart, i), new Vector2(sxLineEnd, i), lineWidth);
+        }
+
+        // Primary color
+        for (let i = pyLineStart; i < bottomRight.y; i += unitSize * 10) {
+            let color = mainColor;
+            if (i === offset.y % (unitSize)) { color = originColor; }
+            if (i > syLineStart) {
+                this.DrawLine(color, new Vector2(sxLineStart, i), new Vector2(sxLineEnd, i), lineWidth);
+                if (showUnits) { this.DrawText(String(i), new Vector2(topLeft.x, i).add(new Vector2(5, -5)), color, unitFont); }
+            }
+        }
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,10 +23,10 @@ function OnFrameUpdate(timestamp: number): void {
     const dt = CalculateDeltaTime(timestamp);
 
     canvasManager.CanvasRenderer().ClearCanvas();
+    canvasManager.CanvasMovement().UpdateCanvasTranslation(dt);
+    canvasManager.CanvasRenderer().DrawGrid();
     canvasManager.CanvasRenderer().DrawCircle("yellow", new Vector2(50, 50), 10);
     canvasManager.CanvasRenderer().DrawCircle("red", new Vector2(-50, -50), 10);
-
-    canvasManager.CanvasMovement().UpdateCanvasTranslation(dt);
 
     requestAnimationFrame(OnFrameUpdate);
 }


### PR DESCRIPTION
Description
This pull request adds a new feature to the CanvasRenderer class: a DrawGrid method that draws a grid on the canvas.

The DrawGrid method takes a params parameter that specifies the properties of the grid to be drawn. The params parameter is an optional object that conforms to the GridProperties interface. If the params parameter is not specified, the default grid properties are used.

The DrawGrid method draws a grid with the specified properties on the canvas. The grid consists of main lines, secondary lines, and an origin point. The main lines are drawn with the mainColor property, the secondary lines are drawn with the secondaryColor property, and the origin point is drawn with the originColor property. The width of the lines is specified by the lineWidth property, and the size of each grid unit is specified by the unitSize property. The offset of the grid from the canvas origin is specified by the offset property.

The DrawGrid method also optionally draws unit labels along the grid lines. If the showUnits property is set to true, the unit labels are drawn using the unitFont property.

This closes #8 